### PR TITLE
Fix README instructions and add CLI script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# Mktng-Calculator.
-Herramienta Python para calcular el ROI de inversiones empresariales. Ofrece una API para integración web, facilitando análisis rápidos y precisos. Instalación: git clone, pip install -r requirements.txt, ejecutar con python main.py. Contribuciones vía issues y PRs son bienvenidas.
+# Mktng-Calculator
+
+Herramienta Python para calcular métricas de marketing como ROI, CPC, CPA y tasa de conversión. El repositorio incluye `main.py`, un script interactivo que solicita los datos necesarios, valida que sean positivos y muestra los resultados.
+
+## Uso
+1. Clona el repositorio.
+2. Ejecuta `python main.py` y sigue las instrucciones en pantalla.
+
+Las contribuciones vía issues y PRs son bienvenidas.

--- a/main.py
+++ b/main.py
@@ -1,0 +1,53 @@
+def calcular_roi(ganancia, costo):
+    """Calcula el Retorno de Inversión (ROI)."""
+    if costo <= 0:
+        raise ValueError("El costo debe ser mayor que 0.")
+    return (ganancia - costo) / costo * 100
+
+
+def calcular_cpc(costo_total, total_clics):
+    """Calcula el Costo Por Clic (CPC)."""
+    if total_clics <= 0:
+        raise ValueError("El total de clics debe ser mayor que 0.")
+    return costo_total / total_clics
+
+
+def calcular_cpa(costo_total, total_adquisiciones):
+    """Calcula el Costo Por Adquisición (CPA)."""
+    if total_adquisiciones <= 0:
+        raise ValueError("El total de adquisiciones debe ser mayor que 0.")
+    return costo_total / total_adquisiciones
+
+
+def calcular_tasa_conversion(total_conversiones, total_acciones):
+    """Calcula la tasa de conversión como un porcentaje."""
+    if total_acciones <= 0:
+        raise ValueError("El total de acciones debe ser mayor que 0.")
+    return (total_conversiones / total_acciones) * 100
+
+
+def simulacion_inputs_usuario():
+    """Simula inputs del usuario y muestra los resultados."""
+    try:
+        presupuesto_total = float(input("Introduce tu presupuesto total: "))
+        ganancia_total_esperada = float(input("Introduce la ganancia total esperada: "))
+        total_clics_esperados = float(input("Introduce el total de clics esperados: "))
+        total_adquisiciones_esperadas = float(input("Introduce el total de adquisiciones esperadas: "))
+        total_conversiones_esperadas = float(input("Introduce el total de conversiones esperadas: "))
+
+        roi = calcular_roi(ganancia_total_esperada, presupuesto_total)
+        cpc = calcular_cpc(presupuesto_total, total_clics_esperados)
+        cpa = calcular_cpa(presupuesto_total, total_adquisiciones_esperadas)
+        tasa_conversion = calcular_tasa_conversion(total_conversiones_esperadas, total_clics_esperados)
+
+        print("\nResultados basados en los inputs:")
+        print(f"ROI: {roi:.2f}%")
+        print(f"CPC: ${cpc:.2f}")
+        print(f"CPA: ${cpa:.2f}")
+        print(f"Tasa de conversión: {tasa_conversion:.2f}%")
+    except ValueError as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    simulacion_inputs_usuario()


### PR DESCRIPTION
## Summary
- add `main.py` script with ROI, CPC, CPA and conversion functions
- update README with correct usage instructions
- improve validation for positive input values

## Testing
- `python -m py_compile main.py`
- `python main.py <<'EOF'
100
200
50
10
5
EOF`


------
https://chatgpt.com/codex/tasks/task_e_687323dfdbf083289a70d9e76796db3b